### PR TITLE
more defensive programming

### DIFF
--- a/core/src/main/java/net/data/technology/jraft/RaftServer.java
+++ b/core/src/main/java/net/data/technology/jraft/RaftServer.java
@@ -262,7 +262,7 @@ public class RaftServer implements RaftMessageHandler {
                 if(logEntry.getValueType() == LogValueType.Configuration){
                     this.logger.info("received a configuration change at index %d from leader", indexForEntry);
                     this.configChanging = true;
-                }else{
+                } else if(logEntry.getValueType() == LogValueType.Application) {
                     this.stateMachine.preCommit(indexForEntry, logEntry.getValue());
                 }
             }


### PR DESCRIPTION
more defensive programming, if we don't check the value type, the misbehave of the peer will lead to state machine corruption.
I call this as a defensive programming is because Raft is not a Byzantine problem safe algorithm, if peers could misbehavior, this cannot save overall correctness